### PR TITLE
fix(index.tsx): injectVoiceUsers()

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -163,7 +163,7 @@ export function injectSlateMention(id: string, guildId?: string): HTMLAttributes
 
 async function injectVoiceUsers(): Promise<void> {
   const voiceUserMod = await waitForModule<Record<string, Function>>(
-    filters.bySource(".userNameClassName"),
+    filters.bySource("userNameClassName"),
   );
   const voiceUserModExport = Object.values(voiceUserMod).find(
     (x) =>


### PR DESCRIPTION
discord seems to have removed the "." in .userNameClassName, which breaks the filters.bySource.

replugged.webpack.getBySource("userNameClassName", {all: true})

returns the 1 module

Fix was tested 24/11/2023 15:10:00
![image](https://github.com/asportnoy/role-color-everywhere/assets/39556336/c5646347-0319-48c5-ab2b-0861bb678583)


(closes https://github.com/asportnoy/role-color-everywhere/issues/4)